### PR TITLE
Changed reference to Advanced tab to SQL tab

### DIFF
--- a/web/templates/page/docs.html.eex
+++ b/web/templates/page/docs.html.eex
@@ -95,7 +95,7 @@
   ]
 }
 	</pre>
-    <p>Information on what fields are available can be found in the Advanced tab, although an API may be made available to access the schema for a service directly in future.</p>
+    <p>Information on what fields are available can be found in the SQL tab, although an API may be made available to access the schema for a service directly in future.</p>
 
     <h3 id="sql">Using SQL</h3>
 

--- a/web/templates/page/docs.html.eex
+++ b/web/templates/page/docs.html.eex
@@ -94,13 +94,11 @@
     }
   ]
 }
-<<<<<<< HEAD
-	</pre>
+    </pre>
     <p>Information on what fields are available can be found in the SQL tab, although an API may be made available to access the schema for a service directly in future.</p>
-=======
+
     </pre>
     <p>Information on what fields are available can be found in the Advanced tab, although an API may be made available to access the schema for a service directly in future.</p>
->>>>>>> origin/master
 
     <h3 id="sql">Using SQL</h3>
 


### PR DESCRIPTION
Removed "Advanced tab" in docs and replaced with "SQL tab"

_(apologies for the remote-tracking merge)_
