### PR TITLE
Added multiple filter explanation

### DIFF
--- a/web/templates/page/docs.html.eex
+++ b/web/templates/page/docs.html.eex
@@ -95,6 +95,9 @@
   ]
 }
     </pre>
+
+    <p>Multiple filters can be applied through the use of the &amp; operator. For example, to return all planned road works on the M1 where the local_authority is "Leicestershire / Northamptonshire" a request should be made to <span class="special"><a target="_blank" href="/data/api/service/transport/planned_road_works?road=M1&local_authority=Leicestershire / Northamptonshire"><%= get_host(@conn) %>/data/api/service/transport/planned_road_works?road=M1&local_authority=Leicestershire / Northamptonshire</a></span></p>
+
     <p>Information on what fields are available can be found in the SQL tab, although an API may be made available to access the schema for a service directly in future.</p>
 
     <h3 id="sql">Using SQL</h3>

--- a/web/templates/page/docs.html.eex
+++ b/web/templates/page/docs.html.eex
@@ -59,7 +59,7 @@
     <p>The list of service endpoints for a given theme is also available, for example <span class="special"><a href="/data/api/service/health"><%= get_host(@conn) %>/data/api/service/health</a></span></p>
 
     <h3 id="predefined">Pre-defined queries</h3>
-    <p>Within each theme, most services have a list of <a href="/health">pre-defined</a> queries that can be used and completed by the user.  This functionality can be replicated by using the filter api below.</p>
+    <p>Within each theme, most services have a list of pre-defined queries (such as those for the <a href="/data/api/health">health theme</a>) that can be used and completed by the user.  This functionality can be replicated by using the filter api below.</p>
 
     <p>It is possible however, for each theme and service, to get a list of the known distinct fields.  These fields have been identified as containing a limited set of values and are therefore available for use.  They can be accessed at <span class="special"><a href="/data/api/service/health/distinct"><%= get_host(@conn) %>/data/api/service/health/distinct</a></span>.  It is also possible to get the distinct values for a single service, so social_care_locations within health would be <span class="special"><a href="/data/api/service/health/distinct/social_care_locations"><%= get_host(@conn) %>/data/api/service/health/distinct/social_care_locations</a></span>.</p>
 


### PR DESCRIPTION
C1. Gave a simple example of how to filter against multiple parameters using the & operator

E.g: planned_road_works?road=M1&local_authority=Leicestershire

C2. Fixing broken link to /health in the 'pre-defined queries' section of the docs
